### PR TITLE
fixes the fakelogin function for non accessable callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc",
+    "build": "./node_modules/.bin/tsc",
     "prepare": "npm run build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ export default class Bexio {
                 jar: cookieJar,
                 simple: false,
                 resolveWithFullResponse: true,
-                followAllRedirects: true,
+                followAllRedirects: false,
                 form: {
                     'confirm_scopes[_csrf_token]': csrfToken2,
                     authorize: 1
@@ -236,7 +236,7 @@ export default class Bexio {
             throw new Error('Failed at step 4: accept the requested scopes')
         }
 
-        let responseURL = new URL(res.request.href)
+        let responseURL = new URL(res.headers.location)
         return this.generateAccessToken({
             code: responseURL.searchParams.get('code') || '',
             state: responseURL.searchParams.get('state') || ''


### PR DESCRIPTION
step 4 on the fakelogin functionality failed if the callback url was not available / reachable. This is fixed that the function now uses the response from bexio instead of trying to reach the callback