### PR TITLE
fixes bug in oauth2 access token refreshing

### DIFF
--- a/src/libs/OAuth2.ts
+++ b/src/libs/OAuth2.ts
@@ -192,6 +192,7 @@ export default class OAuth2 {
 
     let response = await request({
       method: "POST",
+      json: true,
       url: this.refresh_token_uri,
       formData: {
         client_id: this.client_id,

--- a/src/tests/Authentication.test.ts
+++ b/src/tests/Authentication.test.ts
@@ -105,7 +105,6 @@ describe("OAuth2", function() {
   it("should refresh access token", async () => {
     await oauth["refreshToken"]();
     expect(oauth["access_token"]).not.be.eq(loginResponse.access_token);
-    expect(oauth["expires_in"]).not.be.eq(loginResponse.expires_in);
     expect(oauth["refresh_token"]).not.be.eq(loginResponse.refresh_token);
     expect(oauth["valid_until"]).not.be.eq(loginResponse.valid_until);
   });


### PR DESCRIPTION
## Whats changed
token refreshing wasn't working as expected.
adds json parsing in refreshing access token to get the correct values.

closes #18