### PR TITLE
chore: bump version to 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bexio",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "NPM Package for the api of bexio.com",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Releases changes introduced with version 3.6.0 properly. Includes now the built changes.

Closes #83 