### PR TITLE
feat(invoices): add issue and markAsSent methods

### DIFF
--- a/src/interfaces/InvoicesStatic.ts
+++ b/src/interfaces/InvoicesStatic.ts
@@ -111,7 +111,7 @@ export namespace InvoicesStatic {
     updated_at = "updated_at",
   }
 
-  export interface InvoiceSent {
+  export interface InvoiceSend {
     recipient_email: string;
     subject: string;
     message: string;
@@ -119,8 +119,17 @@ export namespace InvoicesStatic {
     attach_pdf?: boolean;
   }
 
+  /**
+   * @deprecated Use `InvoiceSend` instead.
+   */
+  export type InvoiceSent = InvoiceSend;
+
   export interface InvoiceCancelled {
     success: boolean
+  }
+
+  export interface InvoiceIssued {
+    success: boolean;
   }
 
   export interface InvoiceSentAnswer {

--- a/src/resources/Invoices.ts
+++ b/src/resources/Invoices.ts
@@ -17,9 +17,18 @@ export default class Invoices extends BaseCrud<
   constructor(apiToken: string) {
     super(apiToken, "/2.0/kb_invoice");
   }
-  public async sent(
+
+  /**
+   * Send an invoice by email.
+   *
+   * @param {number} id
+   * @param {Partial<InvoicesStatic.InvoiceSend>} ressource
+   * @returns {Promise<InvoicesStatic.InvoiceSentAnswer>}
+   * @memberof Invoices
+   */
+  public async send(
     id: number,
-    ressource: Partial<InvoicesStatic.InvoiceSent>
+    ressource: Partial<InvoicesStatic.InvoiceSend>
   ): Promise<InvoicesStatic.InvoiceSentAnswer> {
     return this.request<InvoicesStatic.InvoiceSentAnswer>(
       "POST",
@@ -29,10 +38,50 @@ export default class Invoices extends BaseCrud<
     );
   }
 
+  /**
+   * @deprecated Use `send` instead.
+   */
+  public async sent(
+    id: number,
+    ressource: Partial<InvoicesStatic.InvoiceSend>
+  ): Promise<InvoicesStatic.InvoiceSentAnswer> {
+    return this.send(id, ressource);
+  }
+
   public async cancel(id: number): Promise<InvoicesStatic.InvoiceCancelled> {
     return this.request<InvoicesStatic.InvoiceCancelled>(
       "POST",
       `${this.apiEndpoint}/${id}/cancel`,
+    );
+  }
+
+  /**
+   * Issue an invoice. The invoice must be in the draft status.
+   *
+   * @param {number} id
+   * @returns {Promise<InvoicesStatic.InvoiceIssued>}
+   * @memberof Invoices
+   */
+  public async issue(id: number): Promise<InvoicesStatic.InvoiceIssued> {
+    return this.request<InvoicesStatic.InvoiceIssued>(
+      "POST",
+      `${this.apiEndpoint}/${id}/issue`
+    );
+  }
+
+  /**
+   * Mark an invoice as sent.
+   *
+   * @param {number} id
+   * @returns {Promise<InvoicesStatic.InvoiceSentAnswer>}
+   * @memberof Invoices
+   */
+  public async markAsSent(
+    id: number
+  ): Promise<InvoicesStatic.InvoiceSentAnswer> {
+    return this.request<InvoicesStatic.InvoiceSentAnswer>(
+      "POST",
+      `${this.apiEndpoint}/${id}/mark_as_sent`
     );
   }
 

--- a/src/tests/Invoices.test.ts
+++ b/src/tests/Invoices.test.ts
@@ -31,24 +31,52 @@ describe("Invoices", () => {
     expect(invoices.apiEndpoint).toBe("/2.0/kb_invoice");
   });
 
-  describe("sent", () => {
+  describe("send", () => {
     it("Should call request with POST and correct path", async () => {
       const invoices = new Invoices(chance.string());
       const id = chance.integer();
-      const sentData: Partial<InvoicesStatic.InvoiceSent> = {
+      const sendData: Partial<InvoicesStatic.InvoiceSend> = {
         recipient_email: chance.email(),
         subject: chance.string(),
         message: chance.string(),
         mark_as_open: true,
       };
 
-      await invoices.sent(id, sentData);
+      await invoices.send(id, sendData);
 
       expect(requestSpy).toHaveBeenCalledWith(
         "POST",
         `/2.0/kb_invoice/${id}/send`,
         undefined,
-        sentData
+        sendData
+      );
+    });
+  });
+
+  describe("issue", () => {
+    it("Should call request with POST and correct path", async () => {
+      const invoices = new Invoices(chance.string());
+      const id = chance.integer();
+
+      await invoices.issue(id);
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        `/2.0/kb_invoice/${id}/issue`
+      );
+    });
+  });
+
+  describe("markAsSent", () => {
+    it("Should call request with POST and correct path", async () => {
+      const invoices = new Invoices(chance.string());
+      const id = chance.integer();
+
+      await invoices.markAsSent(id);
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        `/2.0/kb_invoice/${id}/mark_as_sent`
       );
     });
   });


### PR DESCRIPTION
This adds support for [issue an invoice](https://docs.bexio.com/#tag/Invoices/operation/v2IssueInvoice) and [mark invoice as sent](https://docs.bexio.com/#tag/Invoices/operation/v2RMarkAsSentInvoice).

bexio API to change invoice status is quite confusing IMHO:
- `issue` changes the status to "pending" without creating any communication
- `markAsSend` creates a manual communication, which I believe can only only be recovered from the [web interface](https://office.bexio.com/index.php/tc) and not from the API
- `send` both changes the status to "pending" and create/trigger an email communication (and optionally mark the email as seen)

<img width="647" height="199" alt="image" src="https://github.com/user-attachments/assets/bf5e363d-653f-42eb-880b-42512f5c7b31" />

This PR also renames the `sent()` function to `send()` (`sent()` still available as deprecated) to better match the bexio API and documentation.